### PR TITLE
UI μImprovements

### DIFF
--- a/src/controller/App.controller.ts
+++ b/src/controller/App.controller.ts
@@ -17,6 +17,7 @@ export default class AppController extends BaseController {
             busy: false,
             delay: 0,
             layout: "OneColumn",
+            navButtonVisible: false,
             previousLayout: "",
             actionButtonsInfo: {
                 midColumn: {
@@ -27,6 +28,8 @@ export default class AppController extends BaseController {
         this.setModel(viewModel, "appView");
         let ownerComponent = this.getOwnerComponent() as Component;
         this.getView().addStyleClass(ownerComponent.getContentDensityClass());
+        const router = ownerComponent.getRouter();
+        router.attachRoutePatternMatched(this.onRoutePatternMatched, this);
     }
 
     handleNotificationsPress(event: Event): void {
@@ -46,5 +49,14 @@ export default class AppController extends BaseController {
         } else {
             notifManager.dismissAllNotifications();
         }
+    }
+
+    /**
+     * Listen to router changes that may affect App-wide settings.
+     * @param event
+     */
+    private onRoutePatternMatched(event: Event): void {
+        const rName = event.getParameter("name");
+        (this.getModel("appView") as JSONModel).setProperty("/navButtonVisible", rName !== "master");
     }
 }

--- a/src/controller/App.controller.ts
+++ b/src/controller/App.controller.ts
@@ -62,7 +62,6 @@ export default class AppController extends BaseController {
         if (suggestionItem) {
             const station = suggestionItem.getBindingContext().getProperty("guid");
             let replace = !DeviceSystem.phone;
-            (this.getModel("appView") as JSONModel).setProperty("/layout", "TwoColumnsMidExpanded");
             this.getRouter().navTo("stationPlayer", {
                 stationGuid: station
             }, undefined, replace);

--- a/src/controller/Master.controller.ts
+++ b/src/controller/Master.controller.ts
@@ -145,7 +145,6 @@ export default class MasterController extends BaseController {
 
     private showDetail(item: any): void {
         let replace = !DeviceSystem.phone;
-        (this.getModel("appView") as JSONModel).setProperty("/layout", "TwoColumnsMidExpanded");
         this.getRouter().navTo("stationPlayer", {
             stationGuid: (item as ObjectListItem).getBindingContext().getProperty("guid")
         }, undefined, replace);

--- a/src/controller/Master.controller.ts
+++ b/src/controller/Master.controller.ts
@@ -9,9 +9,11 @@ import FilterType from "sap/ui/model/FilterType";
 import JSONModel from "sap/ui/model/json/JSONModel";
 import ListBinding from "sap/ui/model/ListBinding";
 import Component from "src/Component";
+import { Channel, PlayerEvent } from "./../model/EventBusEnum";
 import LocalStorageModel from "src/model/LocalStorageModel";
 import BaseController from "./BaseController";
 import EditableView from "./util/EditableView";
+import SearchField from "sap/m/SearchField";
 
 type FilterState = {
     search: Filter[]
@@ -53,6 +55,8 @@ export default class MasterController extends BaseController {
         this.filterState = {
             search: []
         };
+        const evtBus = this.getOwnerComponent().getEventBus();
+        evtBus.subscribe(Channel.Player, PlayerEvent.Search, this.onEventPublished, this);
     }
 
     onMasterMatched(): void {
@@ -126,6 +130,17 @@ export default class MasterController extends BaseController {
 
     private applyFilterSearch(): void {
         (this.list.getBinding("items") as ListBinding).filter(this.filterState.search, FilterType.Application)
+    }
+
+    private onEventPublished(channel: string, eventId: String, data: any) {
+        switch (eventId) {
+            case PlayerEvent.Search:
+                // Sync Playlist search input and dispatch search.
+                const query = data.getParameter("query");
+                (this.byId("searchField") as SearchField).setValue(query);
+                this.onSearch(data);
+                break;
+        }
     }
 
     private showDetail(item: any): void {

--- a/src/controller/Master.controller.ts
+++ b/src/controller/Master.controller.ts
@@ -56,6 +56,7 @@ export default class MasterController extends BaseController {
     }
 
     onMasterMatched(): void {
+        (this.getOwnerComponent() as Component).listSelector.clearMasterListSelection();
         (this.getModel("appView")as JSONModel).setProperty("/layout", "OneColumn");
         this.masterModel.setProperty("/mode", EditableView.mode.Display);
         this.masterModel.setProperty("/listItemType", ListType.Active);

--- a/src/model/EventBusEnum.ts
+++ b/src/model/EventBusEnum.ts
@@ -1,0 +1,12 @@
+/*
+ * @copyright ${copyright}
+ */
+
+export enum Channel {
+    Player = "player"
+}
+
+export enum PlayerEvent {
+    Play = "play",
+    Search = "search"
+}

--- a/src/view/App.view.xml
+++ b/src/view/App.view.xml
@@ -21,6 +21,20 @@
                     showNotifications="true"
                     notificationsPressed=".handleNotificationsPress"
                     notificationsNumber="{= ${notifications>/}.length}">
+                    <f:searchManager>
+                        <f:SearchManager id="searchField"
+                            search="handleSearch"
+                            enableSuggestions="true"
+                            suggestionItems="{
+                                path: '/stations',
+                                sorter: { path: 'name' }
+                            }"
+                            suggest="handleSearchSuggest">
+                            <f:suggestionItems>
+                                <SuggestionItem text="{name}" key="{guid}"/>
+                            </f:suggestionItems>
+                        </f:SearchManager>
+                    </f:searchManager>
                 </f:ShellBar>
             </customHeader>
             <content>

--- a/src/view/App.view.xml
+++ b/src/view/App.view.xml
@@ -16,6 +16,8 @@
             <customHeader>
                 <f:ShellBar
                     title="{i18n>appTitle}"
+                    navButtonPressed=".onNavBack"
+                    showNavButton="{appView>/navButtonVisible}"
                     showNotifications="true"
                     notificationsPressed=".handleNotificationsPress"
                     notificationsNumber="{= ${notifications>/}.length}">

--- a/src/view/StationPlayer.view.xml
+++ b/src/view/StationPlayer.view.xml
@@ -13,7 +13,7 @@
     <semantic:SemanticPage id="page"
         busy="{detailView>/busy}"
         busyIndicatorDelay="{detailView>/delay}"
-        showFooter="true">
+        showFooter="false">
         <semantic:titleHeading>
             <Title
                 text="{name}"/>

--- a/src/view/StationPlayer.view.xml
+++ b/src/view/StationPlayer.view.xml
@@ -30,8 +30,8 @@
                 <Button press=".togglePlay" icon="{stationView>/playbackButton}" type="Transparent"/>
                 <Button press=".onStop" icon="sap-icon://stop" type="Transparent"/>
                 
-                <Slider value="100" width="10em" liveChange=".handleVolumeSlider"/>
-                <Button press=".toggleMute" icon="{stationView>/volumeIcon}" type="Transparent"/>
+                <Slider value="100" width="10em" liveChange=".handleVolumeSlider" visible="{device>/system/desktop}"/>
+                <Button press=".toggleMute" icon="{stationView>/volumeIcon}" type="Transparent" visible="{device>/system/desktop}"/>
                 <html:audio id="audioPlayer"
                     controls="true"
                     style="display:none;"
@@ -40,6 +40,7 @@
         </semantic:content>
         <semantic:editAction>
             <semantic:EditAction id="edit"
+                visible="{device>/system/desktop}"
                 press=".onEdit"/>
         </semantic:editAction>
         <semantic:closeAction>

--- a/src/view/StationPlayer.view.xml
+++ b/src/view/StationPlayer.view.xml
@@ -45,6 +45,7 @@
         </semantic:editAction>
         <semantic:closeAction>
             <semantic:CloseAction id="closeColumn"
+                visible="{= !${device>/system/phone}}"
                 press=".onCloseStation"/>
         </semantic:closeAction>
         <semantic:fullScreenAction>


### PR DESCRIPTION
AKA fix some oversights of things that doesn't make sense on mobile and hiding things that weren't ready to shine.

- Disable footer
- Volume slider/mute be visible only in Desktop
- Edit button on player be visible only in Desktop
- Clear selection on playlist when returning to it (soft lock on mobile)
- Enable Back NavButton on app.
- Shellbar Search
- Stabilize FlexibleColumnLayout behavior to keep consistent its state when opening a station to play, either by playlist or by Shellbar Search, also preserving if Begin Column was expanded or not prior navigation.