### PR TITLE
Remove build omitted files from generated Cache Buster info file

### DIFF
--- a/task/CacheBusterSqueezer.js
+++ b/task/CacheBusterSqueezer.js
@@ -1,0 +1,21 @@
+/**
+ * Trim CacheBuster info file by removing entries related to files omitted from build.
+ */
+// eslint-disable-next-line no-unused-vars
+module.exports = async function ChacheBusterSqueezer({ workspace, dependencies, taskUtil, options }) {
+  const config = options.configuration;
+  const cachebusterInfoResources = await workspace.byGlob("**/sap-ui-cachebuster-info.json");
+  if (cachebusterInfoResources.length !== 1) {
+    return;
+  }
+  const cachebusterInfoRes = cachebusterInfoResources[0];
+  let cachebusterInfo = JSON.parse(await cachebusterInfoRes.getString());
+
+  for (var resourcePath in cachebusterInfo) {
+    let resource = await workspace.byPath("/resources/"+options.projectNamespace+"/"+resourcePath);
+    if(taskUtil.getTag(resource, taskUtil.STANDARD_TAGS.OmitFromBuildResult)) {
+      delete cachebusterInfo[resourcePath];
+    }
+  }
+  cachebusterInfoRes.setString(JSON.stringify(cachebusterInfo, null, 2));
+};

--- a/ui5.yaml
+++ b/ui5.yaml
@@ -31,8 +31,10 @@ builder:
           - "**/*.js"
           - "!**/sw.js"
           - "!**/Component-preload.js"
-    - name: cacheBusterShaker
+    - name: cacheBusterSqueezer
       afterTask: generateCachebusterInfo
+    - name: cacheBusterShaker
+      afterTask: cacheBusterSqueezer
 
 server:
   customMiddleware:
@@ -62,3 +64,13 @@ metadata:
   name: cacheBusterShaker
 task:
   path: task/CacheBusterShaker.js
+
+---
+specVersion: "2.6"
+kind: extension
+type: task
+metadata:
+  name: cacheBusterSqueezer
+task:
+  path: task/CacheBusterSqueezer.js
+


### PR DESCRIPTION
Standard task responsible for generating Cache Buster file does not consider if a file was tagged with `OmitFromBuildResult` to exclude it from hash list.

Those extra entries does not affect in any way the behavior from PWA cache/cleanup, but having a tidy hash list makes easier to understand/work on cache handling.

A custom task was created to cleanse that info file.