### PR TITLE
Player: simplify by creating Audio element by code

### DIFF
--- a/src/view/StationPlayer.view.xml
+++ b/src/view/StationPlayer.view.xml
@@ -45,12 +45,6 @@
                     <Slider value="100" width="10em" liveChange=".handleVolumeSlider" visible="{device>/system/desktop}"/>
                     <Button press=".toggleMute" icon="{stationView>/volumeIcon}" type="Transparent" visible="{device>/system/desktop}"/>
                     <Button press=".toggleVisualization" icon="sap-icon://image-viewer" type="Transparent" visible="{device>/system/desktop}"/>
-                    <html:audio id="audioPlayer"
-                        controls="true"
-                        style="display:none;"
-                        crossorigin="anonymous"
-                        preload="none"
-                        />
                         </items>
                 </HBox>
             </VBox>


### PR DESCRIPTION
Drops Audio tag declared in XML view to create it by code.
This way there is no need for a wrapping-Promise waiting until element was actually on DOM to release all pending callbacks related to Audio element.