### PR TITLE
Player: add share button (through Web Share API).

### DIFF
--- a/src/controller/StationPlayer.controller.ts
+++ b/src/controller/StationPlayer.controller.ts
@@ -38,6 +38,7 @@ export default class StationPlayerController extends BaseController implements E
         MediaSession.hookStopAction(()=>this.onStop());
         this.stationModel = new JSONModel({
             "playbackButton" : StationPlayerController.icon_play,
+            "shareApiAvailable" : navigator.share ? true : false,
             "visualizationEnabled": false,
             "volume": 100,
             "volumeIcon": StationPlayerController.icon_sound_loud
@@ -56,6 +57,19 @@ export default class StationPlayerController extends BaseController implements E
         this.getRouter().navTo("stationEdit", {
             stationGuid: this.stationGuid
         });
+    }
+
+    onShare(): void {
+        if (!navigator.share) {
+            console.error("Web Share API not available");
+            return;
+        }
+        const station = this.currentStation;
+        navigator.share({
+            title: station.name,
+            text: station.name,
+            url: station.url
+        }).catch((error) => console.error("Error sharing", error));
     }
 
     onStop(): void {

--- a/src/view/StationPlayer.view.xml
+++ b/src/view/StationPlayer.view.xml
@@ -46,6 +46,7 @@
                     <Button press=".toggleMute" icon="{stationView>/volumeIcon}" type="Transparent" visible="{device>/system/desktop}"/>
                     <Button press=".toggleVisualization" icon="sap-icon://image-viewer" type="Transparent" visible="{device>/system/desktop}"/>
                     <html:google-cast-launcher name="cast_button"/>
+                    <Button press=".onShare" icon="sap-icon://share-2" type="Transparent" visible="{: stationView>/shareApiAvailable}"/>
                         </items>
                 </HBox>
             </VBox>


### PR DESCRIPTION
Sharing is caring: specially when some stations can't be played by app (through malformed headers that triggers CORS error) but is fine for playing through a native application (like VLC).